### PR TITLE
fix: Use root query to populate instead of ctx.user

### DIFF
--- a/server/src/graphql/employer/test.js
+++ b/server/src/graphql/employer/test.js
@@ -118,6 +118,7 @@ describe('Employer crud operation', () => {
         query: `
           query {
             user {
+              id
               firstName
               lastName
               email

--- a/server/src/graphql/thread/test.js
+++ b/server/src/graphql/thread/test.js
@@ -34,9 +34,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   // No need to delete threads, as it cascade deletes on user delete
-  await prisma.deleteUser({
-    id: normalUser.id,
-  });
+  try {
+    await prisma.deleteUser({
+      id: normalUser.id,
+    });
+  } catch (e) {
+    console.log('fail gracefully');
+  }
 });
 
 describe('Test thread resolvers', () => {

--- a/server/src/graphql/user/resolver.js
+++ b/server/src/graphql/user/resolver.js
@@ -2,11 +2,8 @@ import { createFragment } from '../utils/fragment';
 
 export default {
   Query: {
-    user: (_, _args, { prisma, user: { id } }, info) => {
-      const fragment = createFragment(info, 'ToUser', 'User');
-
-      return prisma.user({ id }).$fragment(fragment);
-    },
+    user: (_, _args, { prisma, user: { id } }, info) =>
+      prisma.user({ id }, info),
   },
   Mutation: {
     deleteUser: async (_, { id }, { prisma }) => {


### PR DESCRIPTION
The initial code used the logged-in user.id to populate with the asFreelancer and asEmployer fields. This means that the populated user will be the logged-in user, instead of the actual related user from the User field.

Ex:
```
query users {
 asFreelancer
}
```
will return the logged-in user that queried, not the related user. Use root.id to properly populate the user.